### PR TITLE
Lfs fetchexclude

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[lfs]
+	fetchexclude = audiostream/test/test_files

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,4 +61,5 @@ before_script:
   - cmake .. -DCMAKE_BUILD_TYPE=$CONFIG
     
 script:
-  - cmake --build . && git lfs pull && cmake --build . --target test
+  - cmake --build .
+# - cmake --build . && git lfs pull -X "" && cmake --build . --target test


### PR DESCRIPTION
Github limits the bandwidth for lfs files to 1GB per month. Unfortunately we ran out of bandwidth already this month.

The problem is that everyone cloning the ni-media repo will also download the lfs test files ( provided git lfs was installed on the machine ) 

The lfs files ( ca. 15MB) are only needed in order to run the audiostream reference tests. Most users are not interested in running these tests anyways so i added a .lfsconfig file which will skip the lfs download process for these files. Users can still pull in the test files later on by typing : `git lfs pull -X ""` which will override the exclude pattern in the .lfsconfig file. This should greatly reduce the overall lfs bandwidth.

Since we ran out of lfs bandwidth the audiostream tests will fail, so i disabled the tests for now on travis CI.


