### PR TITLE
Feature add linux gstreamer support

### DIFF
--- a/audiostream/CMakeLists.txt
+++ b/audiostream/CMakeLists.txt
@@ -6,7 +6,7 @@ option( NIMEDIA_ENABLE_AIFF_DECODING "Enable ni-media aiff decoding" ON )
 option( NIMEDIA_ENABLE_FLAC_DECODING "Enable ni-media flac decoding" ON )
 option( NIMEDIA_ENABLE_OGG_DECODING  "Enable ni-media ogg decoding" ON )
 
-if ( APPLE OR WIN32 )
+if ( APPLE OR WIN32 OR LINUX )
   option( NIMEDIA_ENABLE_MP3_DECODING  "Enable ni-media mp3 decoding" ON )
   option( NIMEDIA_ENABLE_MP4_DECODING  "Enable ni-media mp4 decoding" ON )
 else()
@@ -20,7 +20,7 @@ else()
   option( NIMEDIA_ENABLE_ITUNES_DECODING "Enable ni-media iTunes decoding" OFF )
 endif()
 
-if( WIN32 )
+if( WIN32 OR LINUX )
   option( NIMEDIA_ENABLE_WMA_DECODING "Enable ni-media wma decoding" ON )
 else()
   option( NIMEDIA_ENABLE_WMA_DECODING "Enable ni-media wma decoding" OFF )
@@ -71,6 +71,7 @@ endif()
 
 set( COMPILE_WITH_COREAUDIO         DONT_COMPILE)
 set( COMPILE_WITH_MEDIA_FOUNDATION  DONT_COMPILE)
+set( COMPILE_WITH_GSTREAMER  				DONT_COMPILE)
 
 #-----------------------------------------------------------------------------------------------------------------------
 # dependencies
@@ -132,6 +133,29 @@ if( NIMEDIA_ENABLE_MP3_DECODING OR NIMEDIA_ENABLE_MP4_DECODING OR NIMEDIA_ENABLE
     set(COMPILE_WITH_MEDIA_FOUNDATION)
 
     list(APPEND codec_libraries mfplat.lib mfreadwrite.lib mfuuid.lib Propsys.lib)
+
+  elseif( LINUX )
+
+    set(COMPILE_WITH_GSTREAMER)
+
+    find_package(Glib REQUIRED)
+    find_package(GStreamer REQUIRED)
+    find_package(GStreamerApp REQUIRED)
+    find_package(GObject REQUIRED)
+
+    if ( NOT TARGET GSTREAMER::gstreamer )
+      message(FATAL_ERROR
+	"You are building ni-media with GStreamer decoding support but the required gstreamer-1.0 library was not found\n"
+	"Make sure library can be found or disable GSTREAMER decoding by setting:\n"
+	" * NIMEDIA_ENABLE_MP3_DECODING = OFF\n"
+	" * NIMEDIA_ENABLE_MP4_DECODING = OFF\n"
+	" * NIMEDIA_ENABLE_WMA_DECODING = OFF\n")
+    endif()
+
+    list(APPEND codec_libraries GSTREAMER::gstreamer)
+    list(APPEND codec_libraries GSTREAMERAPP::gstreamerapp)
+    list(APPEND codec_libraries glib-2.0)
+    list(APPEND codec_libraries gobject-2.0)
 
   else()
 
@@ -228,6 +252,7 @@ add_src_file  (FILES_media_audio_source "src/ni/media/audio/source/container_sou
 add_src_file  (FILES_media_audio_source "src/ni/media/audio/source/core_audio_file_source.cpp"       ${COMPILE_WITH_COREAUDIO}         WITH_HEADER )
 add_src_file  (FILES_media_audio_source "src/ni/media/audio/source/media_foundation_helper.h"        ${COMPILE_WITH_MEDIA_FOUNDATION}              )
 add_src_file  (FILES_media_audio_source "src/ni/media/audio/source/media_foundation_file_source.cpp" ${COMPILE_WITH_MEDIA_FOUNDATION}  WITH_HEADER )
+add_src_file  (FILES_media_audio_source "src/ni/media/audio/source/gstreamer_file_source.cpp" 			 ${COMPILE_WITH_GSTREAMER}  			 WITH_HEADER )
 add_src_file  (FILES_media_audio_source "src/ni/media/audio/source/aiff_source.h"                    ${COMPILE_WITH_AIFF_DECODING}                 )
 add_src_file  (FILES_media_audio_source "src/ni/media/audio/source/aiff_file_source.h"               ${COMPILE_WITH_AIFF_DECODING}                 )
 add_src_file  (FILES_media_audio_source "src/ni/media/audio/source/aiff_vector_source.h"             ${COMPILE_WITH_AIFF_DECODING}                 )

--- a/audiostream/src/ni/media/audio/source/gstreamer_file_source.cpp
+++ b/audiostream/src/ni/media/audio/source/gstreamer_file_source.cpp
@@ -34,6 +34,7 @@
 #include <functional>
 #include <locale>
 #include <iostream>
+#include <algorithm>
 
 #include <gst/app/gstappsink.h>
 
@@ -280,6 +281,13 @@ std::streampos gstreamer_file_source::seek(offset_type off, BOOST_IOS::seekdir w
 
 std::streamsize gstreamer_file_source::read(char* dst, std::streamsize numBytesRequested)
 {
+  return recursive_read(dst, numBytesRequested);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+std::streamsize gstreamer_file_source::recursive_read(char* dst, std::streamsize numBytesRequested)
+{
   auto read_bytes = m_ring_buffer->pull(dst, numBytesRequested);
 
   dst += read_bytes;
@@ -311,7 +319,7 @@ std::streamsize gstreamer_file_source::read(char* dst, std::streamsize numBytesR
         m_ring_buffer->push((char*) mapped.data + for_now, mapped.size - for_now);
         gst_buffer_unmap(buffer, &mapped);
 
-        return read_bytes + read(dst, numBytesRequested);
+        return read_bytes + recursive_read(dst, numBytesRequested);
       }
     }
   }

--- a/audiostream/src/ni/media/audio/source/gstreamer_file_source.cpp
+++ b/audiostream/src/ni/media/audio/source/gstreamer_file_source.cpp
@@ -1,0 +1,295 @@
+//
+// Copyright (c) 2017 Native Instruments GmbH, Berlin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#include "gstreamer_file_source.h"
+
+#include <ni/media/audio/iotools.h>
+#include <ni/media/iostreams/positioning.h>
+
+#include <boost/algorithm/clamp.hpp>
+#include <boost/algorithm/cxx11/any_of.hpp>
+#include <boost/format.hpp>
+#include <boost/make_unique.hpp>
+
+#include <codecvt>
+#include <functional>
+#include <locale>
+#include <iostream>
+
+#include <gst/app/gstappsink.h>
+
+namespace detail
+{
+  template<typename T, size_t s>
+    struct RingBuffer
+    {
+        static constexpr size_t size = s;
+        static constexpr size_t mask = (s - 1);
+        std::vector<T> m_buffer;
+        uint64_t m_write_head = 0;
+        uint64_t m_read_head = 0;
+
+        void push(const T* data, size_t count)
+        {
+          if(count)
+          {
+            auto idx = m_write_head & mask;
+            auto space = size - idx;
+            auto for_now = std::min(space, count);
+            std::copy(data, data + for_now, m_buffer.begin() + idx);
+            m_write_head += for_now;
+            push(data + for_now, count - for_now);
+          }
+        }
+
+        size_t pull(T* data, size_t count)
+        {
+          count = std::min(count, m_write_head - m_read_head);
+
+          if(count)
+          {
+            auto idx = m_read_head & mask;
+            auto space = size - idx;
+            auto for_now = std::min(space, count);
+            std::copy(m_buffer.begin() + idx, m_buffer.begin() + idx + for_now, data);
+            m_read_head += for_now;
+            return for_now + pull(data + for_now, count - for_now);
+          }
+          return 0;
+        }
+    };
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+gstreamer_file_source::gstreamer_file_source(const std::string& path, audio::ifstream_info::container_type container, size_t stream) :
+    m_pipeline(nullptr, gst_object_unref),
+    m_ring_buffer(new RingBuffer())
+{
+  init_gstreamer();
+  setup_source(path, container);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+gstreamer_file_source::~gstreamer_file_source()
+{
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+void gstreamer_file_source::init_gstreamer()
+{
+  static bool gstreamer_initialized = false;
+
+  if(!std::exchange(gstreamer_initialized, true))
+  {
+    gst_init(0, nullptr);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+void gstreamer_file_source::setup_source(const std::string& path, audio::ifstream_info::container_type container)
+{
+  GstElement* sink = prepare_pipeline(path);
+  auto sinkpad = gst_element_get_static_pad(sink, "sink");
+  auto caps = gst_pad_get_current_caps(sinkpad);
+  auto caps_struct = gst_caps_get_structure(caps, 0);
+  fill_format_info(caps_struct, container);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+GstElement* gstreamer_file_source::prepare_pipeline(const std::string& path)
+{
+  m_pipeline.reset(gst_pipeline_new("pipeline"));
+
+  GstElement* source = gst_element_factory_make("filesrc", "source");
+  GstElement* decodebin = gst_element_factory_make("decodebin", "decoder");
+  GstElement* queue = gst_element_factory_make("queue", "queue");
+  GstElement* sink = gst_element_factory_make("appsink", "sink");
+
+  gst_bin_add_many(GST_BIN(m_pipeline.get()), source, decodebin, queue, sink, nullptr);
+  gst_element_link_many(source, decodebin, NULL);
+  gst_element_link_many(queue, sink, NULL);
+
+  g_object_set(source, "location", path.c_str(), NULL);
+
+  g_signal_connect(decodebin, "pad-added", G_CALLBACK(&onPadAdded), queue);
+
+  preroll_pipeline();
+  return sink;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+void gstreamer_file_source::preroll_pipeline()
+{
+  gst_element_set_state(m_pipeline.get(), GST_STATE_PLAYING);
+  GstState current_state = GST_STATE_VOID_PENDING;
+  GstState pending_state = GST_STATE_VOID_PENDING;
+
+  while(gst_element_get_state(m_pipeline.get(), &current_state, &pending_state, GST_MSECOND) == GST_STATE_CHANGE_ASYNC)
+  {
+    g_main_context_iteration(nullptr, FALSE);
+  }
+
+  std::cerr << "Pipeline is in state: " << current_state << std::endl;
+
+  if(current_state != GST_STATE_PLAYING)
+  {
+    auto res = gst_element_get_state(m_pipeline.get(), &current_state, &pending_state, GST_MSECOND);
+    std::cerr << "Pipeline does not preroll: " << res << " " << current_state << std::endl;
+    throw std::runtime_error( "gstreamer_file_source: pipeline doesn't preroll" );
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+void gstreamer_file_source::fill_format_info(GstStructure *caps_struct, audio::ifstream_info::container_type container)
+{
+  m_info.container(container);
+  m_info.codec(audio::ifstream_info::codec_type::mp3);
+  m_info.lossless(false);
+
+  gint64 num_frames = 0;
+  gst_element_query_duration(m_pipeline.get(), GST_FORMAT_DEFAULT, &num_frames);
+  m_info.num_frames(num_frames);
+
+  int sample_rate = 0;
+  gst_structure_get_int(caps_struct, "rate", &sample_rate);
+  m_info.sample_rate(sample_rate);
+
+  int num_channels = 0;
+  gst_structure_get_int(caps_struct, "channels", &num_channels);
+  m_info.num_channels(num_channels);
+
+  m_info.format(create_runtime_format(caps_struct));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+pcm::runtime_format gstreamer_file_source::create_runtime_format(GstStructure* caps_struct)
+{
+  const gchar* format = gst_structure_get_string(caps_struct, "format");
+  pcm::number_type number_type = gst_format_char_to_number_type(format[0]);
+  auto srcDepth = std::atol(format + 1);
+  auto endian = (strcmp(format, "BE") == 0) ? pcm::big_endian : pcm::little_endian;
+  return pcm::runtime_format(number_type, srcDepth, endian);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+pcm::number_type gstreamer_file_source::gst_format_char_to_number_type(const gchar format)
+{
+  if(format == 'U')
+    return pcm::unsigned_integer;
+  else if(format == 'F')
+    return pcm::floating_point;
+
+  return pcm::signed_integer;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+void gstreamer_file_source::onPadAdded(GstElement* element, GstPad* pad, GstElement* sink)
+{
+  tGstPtr<GstPad> sinkpad(gst_element_get_static_pad(sink, "sink"), gst_object_unref);
+  gst_pad_link(pad, sinkpad.get());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+std::streampos gstreamer_file_source::seek(offset_type off, BOOST_IOS::seekdir way )
+{
+  int64_t newPosition = 0;
+
+  if (way == BOOST_IOS::seekdir::_S_beg)
+  {
+    newPosition = off;
+  }
+  else if (way == BOOST_IOS::seekdir::_S_cur)
+  {
+    newPosition =  m_position + off;
+  }
+  else if (way == BOOST_IOS::seekdir::_S_end)
+  {
+    int64_t end = 0;
+    if(!gst_element_query_duration (m_pipeline.get(), GST_FORMAT_DEFAULT, &end))
+    {
+      throw std::runtime_error( "gstreamer_file_source: seeking from end of file impossible - could not query duration" );
+    }
+    newPosition = end + off;
+  }
+
+  if(newPosition != m_position)
+  {
+    m_position = newPosition;
+
+    if(!gst_element_seek_simple(m_pipeline.get(), GST_FORMAT_DEFAULT, (GstSeekFlags)(GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_ACCURATE), m_position))
+    {
+      throw std::runtime_error( "gstreamer_file_source: seeking failed" );
+    }
+  }
+
+  return m_position;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+std::streamsize gstreamer_file_source::read(char* dst, std::streamsize size)
+{
+  auto bytesPerFrame = m_info.bytes_per_frame();
+  auto bufferedBytes = m_ring_buffer->pull(dst, size * bytesPerFrame);
+  auto bufferedFrames = bufferedBytes / bytesPerFrame;
+  dst += bufferedFrames;
+  size -= bufferedFrames;
+
+  tGstPtr<GstElement> sink(gst_bin_get_by_name(GST_BIN(m_pipeline.get()), "sink"), gst_object_unref);
+  GstAppSink *app_sink = reinterpret_cast<GstAppSink *>(sink.get());
+
+  tGstPtr<GstSample> sample(gst_app_sink_pull_sample(app_sink), (GUnref) gst_sample_unref);
+
+  if(sample)
+  {
+    auto buffer = gst_sample_get_buffer(sample.get());
+
+    GstMapInfo mapped;
+
+    if(gst_buffer_map(buffer, &mapped, GST_MAP_READ))
+    {
+      auto numBytesRequested = size * bytesPerFrame;
+      auto for_now = std::min(mapped.size, numBytesRequested);
+
+      std::copy(mapped.data, mapped.data + for_now, dst);
+
+      m_ring_buffer->push((char*) mapped.data + for_now, mapped.size - for_now);
+      bufferedFrames += for_now / bytesPerFrame;
+
+      gst_buffer_unmap(buffer, &mapped);
+    }
+  }
+
+  m_position += bufferedFrames;
+  return bufferedFrames;
+}
+

--- a/audiostream/src/ni/media/audio/source/gstreamer_file_source.h
+++ b/audiostream/src/ni/media/audio/source/gstreamer_file_source.h
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2017 Native Instruments GmbH, Berlin
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#pragma once
+
+#include <boost/icl/interval_set.hpp>
+#include <boost/icl/right_open_interval.hpp>
+#include <boost/iostreams/categories.hpp>
+#include <boost/iostreams/positioning.hpp>
+
+#include <ni/media/audio/ifstream_info.h>
+#include <gst/gst.h>
+
+namespace detail
+{
+  template<typename T, size_t s> struct RingBuffer;
+}
+
+class gstreamer_file_source
+{
+  public:
+    //----------------------------------------------------------------------------------------------------------------------
+
+    using offset_type = boost::iostreams::stream_offset;
+
+    using FrameRange = boost::icl::right_open_interval<offset_type>;
+    using FrameRangeSet = boost::icl::interval_set<FrameRange::domain_type, std::less, FrameRange>;
+
+    template<typename MfType>
+      using MfTypePtr = std::unique_ptr<MfType, std::function<void( MfType* )>>;
+
+    //----------------------------------------------------------------------------------------------------------------------
+
+    explicit gstreamer_file_source(const std::string& path, audio::ifstream_info::container_type container, size_t stream = 0);
+    ~gstreamer_file_source();
+
+    audio::ifstream_info info() const
+    {
+      return m_info;
+    }
+
+    std::streampos seek(offset_type, BOOST_IOS::seekdir );
+    std::streamsize read( char*, std::streamsize );
+
+    private:
+    static void init_gstreamer();
+    static pcm::runtime_format create_runtime_format(GstStructure* caps_struct);
+    static pcm::number_type gst_format_char_to_number_type(const gchar format);
+
+    void setup_source(const std::string& path, audio::ifstream_info::container_type container);
+    GstElement* prepare_pipeline(const std::string& path);
+    void preroll_pipeline();
+    void fill_format_info(GstStructure *caps_struct, audio::ifstream_info::container_type container);
+
+    static void onPadAdded(GstElement* element, GstPad* pad, GstElement* sink);
+
+    audio::ifstream_info m_info;
+    using GUnref = void(*)(gpointer);
+    template<typename T> using tGstPtr = std::unique_ptr<T, GUnref>;
+    tGstPtr<GstElement> m_pipeline;
+
+    using RingBuffer = detail::RingBuffer<char, 8192>;
+    std::unique_ptr<RingBuffer> m_ring_buffer;
+    int64_t m_position = 0;
+  };

--- a/audiostream/src/ni/media/audio/source/gstreamer_file_source.h
+++ b/audiostream/src/ni/media/audio/source/gstreamer_file_source.h
@@ -71,6 +71,7 @@ class gstreamer_file_source
     void preroll_pipeline();
     GstState wait_for_async_operation();
     void fill_format_info(GstStructure *caps_struct, audio::ifstream_info::container_type container);
+    std::streamsize recursive_read(char* dst, std::streamsize numBytesRequested);
 
     static void onPadAdded(GstElement* element, GstPad* pad, GstElement* sink);
 

--- a/audiostream/src/ni/media/audio/source/gstreamer_file_source.h
+++ b/audiostream/src/ni/media/audio/source/gstreamer_file_source.h
@@ -69,6 +69,7 @@ class gstreamer_file_source
     void setup_source(const std::string& path, audio::ifstream_info::container_type container);
     GstElement* prepare_pipeline(const std::string& path);
     void preroll_pipeline();
+    GstState wait_for_async_operation();
     void fill_format_info(GstStructure *caps_struct, audio::ifstream_info::container_type container);
 
     static void onPadAdded(GstElement* element, GstPad* pad, GstElement* sink);
@@ -78,7 +79,7 @@ class gstreamer_file_source
     template<typename T> using tGstPtr = std::unique_ptr<T, GUnref>;
     tGstPtr<GstElement> m_pipeline;
 
-    using RingBuffer = detail::RingBuffer<char, 8192>;
+    using RingBuffer = detail::RingBuffer<char, 65536>;
     std::unique_ptr<RingBuffer> m_ring_buffer;
     int64_t m_position = 0;
   };

--- a/audiostream/src/ni/media/audio/source/mp3_file_source.cpp
+++ b/audiostream/src/ni/media/audio/source/mp3_file_source.cpp
@@ -26,6 +26,8 @@
 #include "core_audio_file_source.h"
 #elif BOOST_OS_WINDOWS
 #include "media_foundation_file_source.h"
+#elif BOOST_OS_LINUX
+#include "gstreamer_file_source.h"
 #endif
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -55,6 +57,8 @@ void mp3_file_source::open( const std::string& path )
     m_impl.reset( new core_audio_file_source( path, audio::ifstream_info::container_type::mp3 ) );
 #elif BOOST_OS_WINDOWS
     m_impl.reset( new media_foundation_file_source( path, audio::ifstream_info::container_type::mp3 ) );
+#elif BOOST_OS_LINUX
+    m_impl.reset( new gstreamer_file_source( path, audio::ifstream_info::container_type::mp3 ) );
 #endif
 }
 

--- a/audiostream/src/ni/media/audio/source/mp3_file_source.h
+++ b/audiostream/src/ni/media/audio/source/mp3_file_source.h
@@ -61,5 +61,7 @@ private:
     std::unique_ptr<class core_audio_file_source> m_impl;
 #elif BOOST_OS_WINDOWS
     std::unique_ptr<class media_foundation_file_source> m_impl;
+#elif BOOST_OS_LINUX
+    std::unique_ptr<class gstreamer_file_source> m_impl;
 #endif
 };

--- a/audiostream/src/ni/media/audio/source/mp4_file_source.cpp
+++ b/audiostream/src/ni/media/audio/source/mp4_file_source.cpp
@@ -26,6 +26,8 @@
 #include "core_audio_file_source.h"
 #elif BOOST_OS_WINDOWS
 #include "media_foundation_file_source.h"
+#elif BOOST_OS_LINUX
+#include "gstreamer_file_source.h"
 #endif
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -55,6 +57,8 @@ void mp4_file_source::open( const std::string& path, size_t stream )
     m_impl.reset( new core_audio_file_source( path, audio::ifstream_info::container_type::mp4, stream ) );
 #elif BOOST_OS_WINDOWS
     m_impl.reset( new media_foundation_file_source( path, audio::ifstream_info::container_type::mp4, stream ) );
+#elif BOOST_OS_LINUX
+    m_impl.reset( new gstreamer_file_source( path, audio::ifstream_info::container_type::mp4 ) );
 #endif
 }
 

--- a/audiostream/src/ni/media/audio/source/mp4_file_source.h
+++ b/audiostream/src/ni/media/audio/source/mp4_file_source.h
@@ -61,5 +61,7 @@ private:
     std::unique_ptr<class core_audio_file_source> m_impl;
 #elif BOOST_OS_WINDOWS
     std::unique_ptr<class media_foundation_file_source> m_impl;
+#elif BOOST_OS_LINUX
+    std::unique_ptr<class gstreamer_file_source> m_impl;
 #endif
 };

--- a/audiostream/src/ni/media/audio/source/wma_file_source.cpp
+++ b/audiostream/src/ni/media/audio/source/wma_file_source.cpp
@@ -22,7 +22,11 @@
 
 #include <ni/media/audio/source/wma_file_source.h>
 
+#if BOOST_OS_WINDOWS
 #include "media_foundation_file_source.h"
+#elif BOOST_OS_LINUX
+#include "gstreamer_file_source.h"
+#endif
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -47,7 +51,11 @@ wma_file_source::wma_file_source( const std::string& path )
 
 void wma_file_source::open( const std::string& path )
 {
+#if BOOST_OS_WINDOWS
     m_impl.reset( new media_foundation_file_source( path, audio::ifstream_info::container_type::wma ) );
+#elif BOOST_OS_LINUX
+    m_impl.reset( new gstreamer_file_source( path, audio::ifstream_info::container_type::wma ) );
+#endif
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/audiostream/src/ni/media/audio/source/wma_file_source.h
+++ b/audiostream/src/ni/media/audio/source/wma_file_source.h
@@ -26,6 +26,7 @@
 
 #include <boost/iostreams/categories.hpp>
 #include <boost/iostreams/positioning.hpp>
+#include <boost/predef.h>
 
 #include <memory>
 
@@ -57,5 +58,9 @@ public:
     auto info() const -> info_type;
 
 private:
+#if BOOST_OS_WINDOWS
     std::unique_ptr<class media_foundation_file_source> m_impl;
+#elif BOOST_OS_LINUX
+    std::unique_ptr<class gstreamer_file_source> m_impl;
+#endif
 };

--- a/cmake/FindGObject.cmake
+++ b/cmake/FindGObject.cmake
@@ -1,0 +1,5 @@
+find_package (PkgConfig REQUIRED)
+pkg_check_modules (GOBJECT2 REQUIRED gobject-2.0)
+
+include_directories (${GOBJECT2_INCLUDE_DIRS})
+link_directories (${GOBJECT2_LIBRARY_DIRS})

--- a/cmake/FindGStreamer.cmake
+++ b/cmake/FindGStreamer.cmake
@@ -1,0 +1,23 @@
+include(FindPackageHandleStandardArgs)
+
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules (GSTREAMER REQUIRED gstreamer-1.0)
+find_library(GSTREAMER_LIBRARY NAMES gstreamer-1.0)
+
+find_package_handle_standard_args(GSTREAMER DEFAULT_MSG GSTREAMER_INCLUDE_DIRS GSTREAMER_LIBRARY)
+mark_as_advanced(GSTREAMER_INCLUDE_DIRS GSTREAMER_LIBRARY)
+
+
+if( GSTREAMER_FOUND )
+	if( NOT TARGET GSTREAMER::gstreamer )
+    add_library(GSTREAMER::gstreamer SHARED IMPORTED)
+    set_target_properties(GSTREAMER::gstreamer PROPERTIES
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION ${GSTREAMER_LIBRARY}
+      INTERFACE_INCLUDE_DIRECTORIES "${GSTREAMER_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${GSTREAMER_LIBRARY}"
+    )
+  endif()
+endif()
+

--- a/cmake/FindGStreamerApp.cmake
+++ b/cmake/FindGStreamerApp.cmake
@@ -1,0 +1,23 @@
+include(FindPackageHandleStandardArgs)
+
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules (GSTREAMERAPP REQUIRED gstreamer-app-1.0)
+find_library(GSTREAMERAPP_LIBRARY NAMES gstapp-1.0)
+
+find_package_handle_standard_args(GSTREAMERAPP DEFAULT_MSG GSTREAMERAPP_INCLUDE_DIRS GSTREAMERAPP_LIBRARY)
+mark_as_advanced(GSTREAMERAPP_INCLUDE_DIRS GSTREAMERAPP_LIBRARY)
+
+
+if( GSTREAMERAPP_FOUND )
+	if( NOT TARGET GSTREAMERAPP::gstreamerapp )
+    add_library(GSTREAMERAPP::gstreamerapp SHARED IMPORTED)
+    set_target_properties(GSTREAMERAPP::gstreamerapp PROPERTIES
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION ${GSTREAMERAPP_LIBRARY}
+      INTERFACE_INCLUDE_DIRECTORIES "${GSTREAMERAPP_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${GSTREAMERAPP_LIBRARY}"
+    )
+  endif()
+endif()
+

--- a/cmake/FindGlib.cmake
+++ b/cmake/FindGlib.cmake
@@ -1,0 +1,5 @@
+find_package (PkgConfig REQUIRED)
+pkg_check_modules (GLIB2 REQUIRED glib-2.0)
+
+include_directories (${GLIB2_INCLUDE_DIRS})
+link_directories (${GLIB2_LIBRARY_DIRS})


### PR DESCRIPTION
If you like, you can pull my attempt of adding mp3, m4a, alac and wma support on linux platform by using gstreamer framework. I didn't manage to have all tests green, though. For example, the 'interlaced_by_67_frames'-tests are off by 1 sample, which I - so far - couldn't find a reason for.

Most likely other people won't notice my fork. I hope, if you pull it into the base fork, we have a higher chance that anyone can help fixing. 