### PR TITLE
Require a minimum version of Boost.

### DIFF
--- a/audiostream/CMakeLists.txt
+++ b/audiostream/CMakeLists.txt
@@ -76,7 +76,8 @@ set( COMPILE_WITH_MEDIA_FOUNDATION  DONT_COMPILE)
 # dependencies
 #-----------------------------------------------------------------------------------------------------------------------
 
-find_package(Boost REQUIRED COMPONENTS iostreams filesystem system)
+set(BOOST_MIN_VERSION "1.61.0")
+find_package(Boost ${BOOST_MIN_VERSION} REQUIRED COMPONENTS iostreams filesystem system)
 
 if( NIMEDIA_ENABLE_MP3_DECODING OR NIMEDIA_ENABLE_MP4_DECODING OR NIMEDIA_ENABLE_WMA_DECODING)
 

--- a/pcm/CMakeLists.txt
+++ b/pcm/CMakeLists.txt
@@ -1,5 +1,5 @@
-
-find_package(Boost REQUIRED)
+set(BOOST_MIN_VERSION "1.61.0")
+find_package(Boost ${BOOST_MIN_VERSION} REQUIRED)
  # Workaroud: older cmake versions do not create an imported target Boost::boost
 if(NOT TARGET Boost::boost)
   add_library(Boost::boost INTERFACE IMPORTED)


### PR DESCRIPTION
The actual version is unable to build on Ubuntu 16.04 with its default Boost 1.58.
It'd be nice to warn the user before it attempts to build the library.