### PR TITLE
Support gaps in wav and aiff files

### DIFF
--- a/audiostream/src/ni/media/audio/aiff/aiff_chunks.h
+++ b/audiostream/src/ni/media/audio/aiff/aiff_chunks.h
@@ -66,7 +66,6 @@ struct Tag
     boost::endian::big_uint32_t id      = 0;
     boost::endian::big_uint32_t length  = 0;
     boost::endian::big_uint32_t subType = 0;
-    std::streamoff              start   = 0;
 };
 
 

--- a/audiostream/src/ni/media/audio/source/aiff_source.h
+++ b/audiostream/src/ni/media/audio/source/aiff_source.h
@@ -79,8 +79,6 @@ auto readAiffHeader( Source& src )
     if ( !fetch( src, aiffTag.id, aiffTag.length, aiffTag.subType ) || aiffTag.id != aiff::tags::form )
         throw std::runtime_error( "Could not read \'FORM\' tag." );
 
-    aiffTag.start = src.seek( 0, BOOST_IOS::cur );
-
     while ( fetch( src, aiffTag.id, aiffTag.length ) )
     {
         // Retrieve the 'COMM' subchunk, which contains the audio format information

--- a/audiostream/src/ni/media/audio/source/aiff_source.h
+++ b/audiostream/src/ni/media/audio/source/aiff_source.h
@@ -81,6 +81,8 @@ auto readAiffHeader( Source& src )
 
     while ( fetch( src, aiffTag.id, aiffTag.length ) )
     {
+        const auto currentOffset = static_cast<uint32_t>( src.seek( 0, BOOST_IOS::cur ) );
+
         // Retrieve the 'COMM' subchunk, which contains the audio format information
         if ( aiffTag.id == aiff::tags::comm )
         {
@@ -205,13 +207,11 @@ auto readAiffHeader( Source& src )
             return info;
         }
 
-        else
-        {
-            static const size_t padSize   = 2;
-            auto                remainder = aiffTag.length % padSize;
-            auto                target    = aiffTag.length + ( remainder != 0 ? padSize - remainder : 0 );
-            src.seek( target, BOOST_IOS::cur );
-        }
+        static const size_t padSize   = 2;
+        auto                remainder = aiffTag.length % padSize;
+        auto                target    = currentOffset + aiffTag.length
+                                        + ( remainder != 0 ? padSize - remainder : 0 );
+        src.seek( target, BOOST_IOS::beg );
     }
 
     throw std::runtime_error( "Could not read \'data\' tag." );

--- a/audiostream/test/test_files/reference_files/sin440.1.44100.44100.s8be.gap.aiff
+++ b/audiostream/test/test_files/reference_files/sin440.1.44100.44100.s8be.gap.aiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68016878cd464fe7af53ecd13376b9ece80e581c1f5a731a37912951efb1cccc
+size 48200

--- a/audiostream/test/test_files/reference_files/sin440.1.44100.44100.u8le.gap.wav
+++ b/audiostream/test/test_files/reference_files/sin440.1.44100.44100.u8le.gap.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:249e971c31411978824d9219a0b518891cf39b1062ea3babc5d3422e5a609fdd
+size 44146

--- a/audiostream/test/test_files/reference_files/sin440.1.48000.48000.s8be.gap.aiff
+++ b/audiostream/test/test_files/reference_files/sin440.1.48000.48000.s8be.gap.aiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb1626a6255200d4cc92ec65cdbc747b7b1f4b4fc72412c1aa3d862666768a8c
+size 52104

--- a/audiostream/test/test_files/reference_files/sin440.1.48000.48000.u8le.gap.wav
+++ b/audiostream/test/test_files/reference_files/sin440.1.48000.48000.u8le.gap.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8659eba8b908b1e7531230e61e11c1658f1eb9bb828baa37ed6175bbf67d65b
+size 48048

--- a/audiostream/test/test_files/reference_files/sin440.1.96000.96000.s8be.gap.aiff
+++ b/audiostream/test/test_files/reference_files/sin440.1.96000.96000.s8be.gap.aiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27e7437d05c3468bf9d26dae5cd6fbc8b2597498cc7cee3e0f7d9402089c2b6b
+size 100112

--- a/audiostream/test/test_files/reference_files/sin440.1.96000.96000.u8le.gap.wav
+++ b/audiostream/test/test_files/reference_files/sin440.1.96000.96000.u8le.gap.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61f9b8d657d41c4ec169d096e0ad2df13c8b376a1207696453c0062e0bcb2a2d
+size 96052

--- a/audiostream/test/test_files/reference_files/sin440.2.44100.44100.s8be.gap.aiff
+++ b/audiostream/test/test_files/reference_files/sin440.2.44100.44100.s8be.gap.aiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64bdf2995ba81a4d75e85dc640bf5000d782bf92b548107a7b926e662f66b800
+size 92316

--- a/audiostream/test/test_files/reference_files/sin440.2.44100.44100.u8le.gap.wav
+++ b/audiostream/test/test_files/reference_files/sin440.2.44100.44100.u8le.gap.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff6a83759ee5bb2b0864383e3a37c51ef34d87c8ecfd5900531c81f7fb16c283
+size 88254

--- a/audiostream/test/test_files/reference_files/sin440.2.48000.48000.s8be.gap.aiff
+++ b/audiostream/test/test_files/reference_files/sin440.2.48000.48000.s8be.gap.aiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f57c3b6a39ec6e83b8789f83b17545249d4108ba5e5ab778f1f84e9df861fc20
+size 100124

--- a/audiostream/test/test_files/reference_files/sin440.2.48000.48000.u8le.gap.wav
+++ b/audiostream/test/test_files/reference_files/sin440.2.48000.48000.u8le.gap.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55e26a3de329529867727ed305e1cd40c1f572d8c7a99fa4aea5c663abe194ea
+size 96058

--- a/audiostream/test/test_files/reference_files/sin440.2.96000.96000.s8be.gap.aiff
+++ b/audiostream/test/test_files/reference_files/sin440.2.96000.96000.s8be.gap.aiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b6f5c2fa3dc47259ac89edd861c0de3c2374fec155dc2b60fd68e261b734931
+size 196128

--- a/audiostream/test/test_files/reference_files/sin440.2.96000.96000.u8le.gap.wav
+++ b/audiostream/test/test_files/reference_files/sin440.2.96000.96000.u8le.gap.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9f3cedc99d65f1135f0836ecba9ae7714414d04fed2a0ec2a00978c755fa54d
+size 192060


### PR DESCRIPTION
Currently, NI Media assumes that the chunks of .wav and .aiff files are exactly as long as the data they contain; in other words, after reading the data of a chunk it assumes that the stream position is now correct for reading the next chunk. In practice this is not always true; I have seen .wav files that have chunks that are longer than the data they contain, i.e. there are gaps (unused bytes) between chunks. I'm not sure these are valid according to the specification (http://www.martinreddy.net/gfx/2d/IFF.txt is somewhat vague about this), but every piece of audio software I have tried supports them, so NI Media should, too.

I wasn't sure how to cover the changes with tests; the last commit shows a hack that I created for my own use while working on the fix. Please advise what to do for real instead.