### PR TITLE
Fix MSVC 2019 build errors and warnings

### DIFF
--- a/audiostream/CMakeLists.txt
+++ b/audiostream/CMakeLists.txt
@@ -318,11 +318,6 @@ target_link_libraries       ( audiostream PUBLIC pcm
 
 if(MSVC)
   target_compile_options( audiostream PRIVATE /wd4351 )  # MSVC new behaviour warning
-  
-  # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4103?view=vs-2019
-  # C4103 alignment changed after including header, may be due to missing #pragma pack(pop)
-  # C5038 data member 'SyncronousByteStream<Source>::ReadResult::m_bytesRead' will be initialized after data member 'SyncronousByteStream<Source>::ReadResult::m_references'
-  target_compile_options( audiostream PRIVATE /wd4103 /wd5038 )
 endif()
 
 target_compile_definitions( audiostream PRIVATE

--- a/audiostream/CMakeLists.txt
+++ b/audiostream/CMakeLists.txt
@@ -318,6 +318,11 @@ target_link_libraries       ( audiostream PUBLIC pcm
 
 if(MSVC)
   target_compile_options( audiostream PRIVATE /wd4351 )  # MSVC new behaviour warning
+  
+  # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4103?view=vs-2019
+  # C4103 alignment changed after including header, may be due to missing #pragma pack(pop)
+  # C5038 data member 'SyncronousByteStream<Source>::ReadResult::m_bytesRead' will be initialized after data member 'SyncronousByteStream<Source>::ReadResult::m_references'
+  target_compile_options( audiostream PRIVATE /wd4103 /wd5038 )
 endif()
 
 target_compile_definitions( audiostream PRIVATE

--- a/audiostream/src/ni/media/audio/os/win/media_foundation_helper.h
+++ b/audiostream/src/ni/media/audio/os/win/media_foundation_helper.h
@@ -68,7 +68,7 @@ class SyncronousByteStream : public IMFByteStream
     auto tell() -> std::streamsize
     {
         auto pos = m_source.seek( boost::iostreams::stream_offset( 0 ), BOOST_IOS::cur );
-        return ( pos == std::streamsize{-1} ) ? m_size : pos;
+        return ( pos == std::streamsize{-1} ) ? m_size : std::streamsize{pos};
     }
 
 public:

--- a/audiostream/src/ni/media/audio/os/win/media_foundation_source.h
+++ b/audiostream/src/ni/media/audio/os/win/media_foundation_source.h
@@ -131,7 +131,7 @@ const auto losslessFormats = {MFAudioFormat_PCM, //
 //----------------------------------------------------------------------------------------------------------------------
 
 template <class Source, typename MfType>
-using MfTypePtr = typename media_foundation_source<Source>::MfTypePtr<MfType>;
+using MfTypePtr = typename media_foundation_source<Source>::template MfTypePtr<MfType>;
 
 template <class C>
 struct get_MF_type_impl : get_MF_type_impl<decltype( &C::operator() )>
@@ -199,7 +199,7 @@ typename media_foundation_source<Source>::offset_type time100nsToFrames( LONGLON
     // We need to be accurate to a single frame when doing this conversion, and the timestamp provided by WMF can be
     // off by a few nanoseconds, so we round it off.
 
-    using return_type = media_foundation_source<Source>::offset_type;
+    using return_type = media_foundation_source<Source>::template offset_type;
     return return_type( std::round( double( time100ns ) * sampleRate / secTo100ns ) );
 }
 


### PR DESCRIPTION
This PR fixes build errors and warnings with MSVC 2019 16.2 using C++14 and above standard