### PR TITLE
Cmake export dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,6 @@ if( NIMEDIA_OPEN_SOURCE )
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ni-mediaConfig.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/ni-mediaConfig.cmake"
     INSTALL_DESTINATION ${CONFIG_DESTINATION}
-    PATH_VARS CONFIG_DESTINATION
   )
 
   write_basic_package_version_file(
@@ -127,7 +126,7 @@ if( NIMEDIA_OPEN_SOURCE )
     EXPORT ni-mediaExport
     FILE ni-mediaTargets.cmake
     NAMESPACE ni::
-    DESTINATION  ${CONFIG_DESTINATION}
+    DESTINATION ${CONFIG_DESTINATION}
   )
 
   install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ if( TARGET ni-media )
   return()
 endif()
 
-project( ni-media )
+project( ni-media
+  VERSION 0.1.0
+)
 
 option( NIMEDIA_OPEN_SOURCE                   "Build ni-media open source version"    ON )
 option( NIMEDIA_TREAT_WARNINGS_AS_ERRORS      "Treat compile warnings as errors"      OFF)
@@ -102,10 +104,40 @@ foreach( target audiostream audiostream_test pcm_test generator )
 endforeach()
 
 
-install(
-    EXPORT ni-mediaExport
-    FILE ni-mediaConfig.cmake
-    NAMESPACE ni::
-    DESTINATION lib/cmake/ni-media
-)
+if( NIMEDIA_OPEN_SOURCE )
+  
+  include(CMakePackageConfigHelpers)
 
+  set(CONFIG_DESTINATION lib/cmake/ni-media)
+
+  configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ni-mediaConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/ni-mediaConfig.cmake"
+    INSTALL_DESTINATION ${CONFIG_DESTINATION}
+    PATH_VARS CONFIG_DESTINATION
+  )
+
+  write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/ni-mediaConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+  )
+
+  install(
+    EXPORT ni-mediaExport
+    FILE ni-mediaTargets.cmake
+    NAMESPACE ni::
+    DESTINATION  ${CONFIG_DESTINATION}
+  )
+
+  install(
+    FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/ni-mediaConfig.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/ni-mediaConfigVersion.cmake
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindFLAC.cmake
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindOgg.cmake
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindVorbis.cmake             
+    DESTINATION
+      ${CONFIG_DESTINATION}
+  )
+endif()

--- a/cmake/ni-mediaConfig.cmake.in
+++ b/cmake/ni-mediaConfig.cmake.in
@@ -1,8 +1,6 @@
 @PACKAGE_INIT@
 
-set_and_check(NI_MEDIA_CONFIG_DIR "@PACKAGE_CONFIG_DESTINATION@")
-
-list(APPEND CMAKE_MODULE_PATH ${NI_MEDIA_CONFIG_DIR})
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 
 find_package(Boost "1.61.0" REQUIRED COMPONENTS iostreams filesystem system program_options regex)
 
@@ -14,4 +12,4 @@ if(@NIMEDIA_ENABLE_OGG_DECODING@)
   find_package(Vorbis REQUIRED)
 endif()
 
-include(${NI_MEDIA_CONFIG_DIR}/ni-mediaTargets.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ni-mediaTargets.cmake)

--- a/cmake/ni-mediaConfig.cmake.in
+++ b/cmake/ni-mediaConfig.cmake.in
@@ -1,8 +1,11 @@
 @PACKAGE_INIT@
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
-
 find_package(Boost "1.61.0" REQUIRED COMPONENTS iostreams filesystem system program_options regex)
+
+# for flac and ogg we want to find our own findPackage.cmake modules
+# hence we temporarely set CMAKE_MODULE_PATH to this directory
+set(NIMEDIA_PREVIOUS_MODULE_PATH ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 
 if(@NIMEDIA_ENABLE_FLAC_DECODING@)
   find_package(FLAC REQUIRED)
@@ -12,4 +15,8 @@ if(@NIMEDIA_ENABLE_OGG_DECODING@)
   find_package(Vorbis REQUIRED)
 endif()
 
+set(CMAKE_MODULE_PATH ${NIMEDIA_PREVIOUS_MODULE_PATH})
+
 include(${CMAKE_CURRENT_LIST_DIR}/ni-mediaTargets.cmake)
+
+

--- a/cmake/ni-mediaConfig.cmake.in
+++ b/cmake/ni-mediaConfig.cmake.in
@@ -1,0 +1,17 @@
+@PACKAGE_INIT@
+
+set_and_check(NI_MEDIA_CONFIG_DIR "@PACKAGE_CONFIG_DESTINATION@")
+
+list(APPEND CMAKE_MODULE_PATH ${NI_MEDIA_CONFIG_DIR})
+
+find_package(Boost "1.61.0" REQUIRED COMPONENTS iostreams filesystem system program_options regex)
+
+if(@NIMEDIA_ENABLE_FLAC_DECODING@)
+  find_package(FLAC REQUIRED)
+endif()
+
+if(@NIMEDIA_ENABLE_OGG_DECODING@)
+  find_package(Vorbis REQUIRED)
+endif()
+
+include(${NI_MEDIA_CONFIG_DIR}/ni-mediaTargets.cmake)


### PR DESCRIPTION
ni-mediaConfig.cmake now pulls in used dependencies via find_package calls, so this doesn't need to be done on the client side anymore.
Added version 0.1.0