### PR TITLE
cmake: lower minimum required to version 3.12.2 with default policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 3.12.4)
-if(POLICY CMP0091)
-  cmake_policy(SET CMP0091 NEW)
-endif()
+cmake_minimum_required(VERSION 3.12.2)
 
 if( TARGET ni-media )
   return()


### PR DESCRIPTION
We can actually lower cmake version to 3.12.2, and use default policies. CMP0091 doesn't seem to be supported by vcpkg yet. 