### PR TITLE
Use 32bit integer to enforce byte alignment while parsing wav sources

### DIFF
--- a/audiostream/src/ni/media/audio/wav/wav_source.h
+++ b/audiostream/src/ni/media/audio/wav/wav_source.h
@@ -203,7 +203,7 @@ auto readWavHeader( Source& src )
             }
         }
 
-        src.seek( ( currentOffset + riffTag.length + 1 ) & 0xfffffe, std::ios_base::beg );
+        src.seek( ( currentOffset + riffTag.length + 1 ) & 0xfffffffe, std::ios_base::beg );
     }
 
     throw std::runtime_error( "Could not read \'data\' tag." );

--- a/audiostream/test/test_files/fuzz_files/21.wav
+++ b/audiostream/test/test_files/fuzz_files/21.wav
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b16269641b70f33dce790647b7aeab40b6a73f6d651ae7d9aabb53df9a89650
+oid sha256:61f1d2619a98bc2a753cf24e09eca80d45bbf14546159e8d6bce2dbac7e85537
 size 44


### PR DESCRIPTION
Extension of #63 , including a fix for a malicious test file, which unblocks CI builds.