### PR TITLE
Prepare 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# 2023-12-20 version v1.1.0:
+
+  * ADDED: Possibility of creating a custom decoder via `istream_source`
+  * ADDED: Possibility of creating a custom byte-stream backend of existing decoders
+  * ADDED: Public access to bit rate for decoders
+  * ADDED: Cmake support for unity builds in the `audiostream` library
+  * CHANGED: Use Github Actions instead of Azure CI
+  * FIXED: An issue where `media_foundation_source` could produce audio crackling on Windows 11
+  * FIXED: An issue where seeking chunks in `wav_source` could result in an infinite loop for long files
+
+# 2020-12-02 version v1.0.0:
+
+  * Initial version tag

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Native Instruments
+Copyright (c) 2023 Native Instruments
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/audiostream/doc/ifstream.md
+++ b/audiostream/doc/ifstream.md
@@ -111,7 +111,7 @@ Best practice to instantiate an `audio::ifstream` based on an `audio::ifstream_s
 audio::ifstream my_ifstream = audio::make_ifstream<my_ifstream_source>( ... );
 ```
 
-## Provideing a custom byte-stream backend
+## Providing a custom byte-stream backend
 
 By implementing the [`audio::custom_backend_source`](../inc/ni/media/audio/custom_backend_source.h) interface, it is possible to provide a custom byte-stream backend to the existing decoders of `ni-media`:
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "ni-media",
-  "version-string": "1.0.0",
+  "version-string": "1.1.0",
   "builtin-baseline": "0526b9cb221ebdc18a8e3de2a25c307a6971bc99",
   "dependencies": [
     "libogg",


### PR DESCRIPTION
We are about to add a `1.1.0` release tag. This PR is a collection of small preparation tasks, which are

* Adding a changelog file
* Increasing the version in the `vcpkg.json` file
* Fixing the copyright year in the `LICENSE` file
* Fixing a spelling mistake in the documentation