### PR TITLE
Fix potential integer overflow at end of stream in media_foundation_helper

### DIFF
--- a/audiostream/src/ni/media/audio/os/win/media_foundation_helper.h
+++ b/audiostream/src/ni/media/audio/os/win/media_foundation_helper.h
@@ -65,6 +65,8 @@ template <class Source>
 class SyncronousByteStream : public IMFByteStream
 {
 
+    static constexpr auto endOfSequence = -1;
+
     auto tell() -> std::streamsize
     {
         auto pos = m_source.seek( boost::iostreams::stream_offset( 0 ), BOOST_IOS::cur );
@@ -86,7 +88,8 @@ public:
 
         try
         {
-            *read = static_cast<ULONG>( m_source.read( reinterpret_cast<char*>( buffer ), toRead ) );
+            const auto result =  m_source.read( reinterpret_cast<char*>( buffer ), toRead );
+            *read = static_cast<ULONG>( result == endOfSequence ? 0 : result );
             return S_OK;
         }
         catch ( const std::system_error& )


### PR DESCRIPTION
If in `SyncronousByteStream::Read`, `m_source.read()` reaches the end of stream, `boost::iostreams::file_descriptor` returns `-1` as an end of stream indicator. Previously, by casting the returned value to `ULONG`, an integer overflow would occur. 
In the attached file, the observed behaviour then would be that the calling code in WMF would continue to attempt to read past the EOF indefinitely or until some unexpected state is reached. 

To fix this, the end of stream indicator (`-1`) is caught and handled as "0 bytes read". 

See the attached [TestMp3.zip](https://github.com/NativeInstruments/ni-media/files/14418477/TestMp3.zip) for a mp3 which triggers this edge case. 

See Issue https://github.com/NativeInstruments/ni-media/issues/73



